### PR TITLE
admin用APIに予約一覧と予約削除を追加

### DIFF
--- a/app/assets/stylesheets/api/admin/appointments.css
+++ b/app/assets/stylesheets/api/admin/appointments.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/controllers/api/admin/appointments_controller.rb
+++ b/app/controllers/api/admin/appointments_controller.rb
@@ -1,2 +1,14 @@
 class Api::Admin::AppointmentsController < ApplicationController
+  before_action :authenticate_administrator!
+
+  def index
+    @appointments = Appointment.all.order(id: :desc)
+    render json: @appointments
+  end
+
+  def destroy
+    id = params.permit(:id)[:id]
+    Appointment.find(id).destroy
+    render json: { "message": '予約を削除しました' }
+  end
 end

--- a/app/controllers/api/admin/appointments_controller.rb
+++ b/app/controllers/api/admin/appointments_controller.rb
@@ -1,0 +1,2 @@
+class Api::Admin::AppointmentsController < ApplicationController
+end

--- a/app/helpers/api/admin/appointments_helper.rb
+++ b/app/helpers/api/admin/appointments_helper.rb
@@ -1,0 +1,2 @@
+module Api::Admin::AppointmentsHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
       get 'menus/index'
       delete 'menus/:id', to: 'menus#destroy'
       delete 'menus', to: 'menus#destroy_all'
+      get 'appointments/index'
+      delete 'appointments/:id', to: 'appointments#destroy'
     end
   end
   get '/admin/*admin_path', to: 'admin#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     end
     namespace :admin do
       get 'menus/index'
-      delete 'menus/:id', to: 'menus#destroy'
+      delete 'menus/:id', to: 'menus#destroy', as: 'menu_destroy'
       delete 'menus', to: 'menus#destroy_all'
       get 'appointments/index'
       delete 'appointments/:id', to: 'appointments#destroy', as: 'appointment_destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       delete 'menus/:id', to: 'menus#destroy'
       delete 'menus', to: 'menus#destroy_all'
       get 'appointments/index'
-      delete 'appointments/:id', to: 'appointments#destroy'
+      delete 'appointments/:id', to: 'appointments#destroy', as: 'appointment_destroy'
     end
   end
   get '/admin/*admin_path', to: 'admin#show'

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -4,4 +4,9 @@ FactoryBot.define do
     start_at { "2021-07-21 09:00:00" }
     end_at { "2021-07-21 09:30:00" }
   end
+  factory :menu_kampo, class: Menu do
+    department { '内科' }
+    start_at { "2021-07-21 09:30:00" }
+    end_at { "2021-07-21 10:00:00" }
+  end
 end

--- a/spec/helpers/api/admin/appointments_helper_spec.rb
+++ b/spec/helpers/api/admin/appointments_helper_spec.rb
@@ -11,5 +11,7 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe Api::Admin::AppointmentsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'is not used' do
+    expect(true).to eq true
+  end
 end

--- a/spec/helpers/api/admin/appointments_helper_spec.rb
+++ b/spec/helpers/api/admin/appointments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::Admin::AppointmentsHelper. For example:
+#
+# describe Api::Admin::AppointmentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::Admin::AppointmentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/admin/menus_helper_spec.rb
+++ b/spec/helpers/api/admin/menus_helper_spec.rb
@@ -11,5 +11,7 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe Api::Admin::MenusHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'is not used' do
+    expect(true).to eq true
+  end
 end

--- a/spec/requests/api/admin/appointments_spec.rb
+++ b/spec/requests/api/admin/appointments_spec.rb
@@ -1,7 +1,33 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Admin::Appointments", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'Api::Admin::Appointments', type: :request do
+  describe 'GET /index' do
+    let!(:administrator) { create(:administrator) }
+    let!(:menu1) { create(:menu) }
+    let!(:menu2) { create(:menu_kampo) }
+    let!(:appointment1) { create(:appointment, menu_id: menu1.id) }
+    let!(:appointment2) { create(:appointment, menu_id: menu2.id) }
+    subject do
+      get api_admin_appointments_index_path, as: :json
+      response
+    end
+    let(:json) { JSON.parse(response.body) }
+
+    context 'when not logged in' do
+      let(:id) { menu.id }
+      it 'returns 401' do
+        expect(subject).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when logged in' do
+      before do
+        sign_in administrator
+      end
+      it 'returns all appointments' do
+        expect(subject).to have_http_status(:ok)
+        expect(json.length).to eq 2
+      end
+    end
   end
 end

--- a/spec/requests/api/admin/appointments_spec.rb
+++ b/spec/requests/api/admin/appointments_spec.rb
@@ -30,4 +30,35 @@ RSpec.describe 'Api::Admin::Appointments', type: :request do
       end
     end
   end
+
+  describe 'DELETE /:id' do
+    let!(:administrator) { create(:administrator) }
+    let!(:menu1) { create(:menu) }
+    let!(:menu2) { create(:menu_kampo) }
+    let!(:appointment1) { create(:appointment, menu_id: menu1.id) }
+    let!(:appointment2) { create(:appointment, menu_id: menu2.id) }
+    subject do
+      delete api_admin_appointment_destroy_path(id), as: :json
+      response
+    end
+    let(:json) { JSON.parse(response.body) }
+
+    context 'when not logged in' do
+      let(:id) { appointment1.id }
+      it 'returns 401' do
+        expect(subject).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when logged in' do
+      let(:id) { appointment1.id }
+      before do
+        sign_in administrator
+      end
+      it 'deletes the appointment' do
+        expect { subject }.to change { Appointment.count }.by(-1)
+        expect(subject).to have_http_status(:ok)
+      end
+    end
+  end
 end

--- a/spec/requests/api/admin/appointments_spec.rb
+++ b/spec/requests/api/admin/appointments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Admin::Appointments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/admin/menus_spec.rb
+++ b/spec/requests/api/admin/menus_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Api::Admin::Menus', type: :request do
     let!(:menu) { create(:menu) }
 
     subject do
-      delete api_admin_path(id), as: :json
+      delete api_admin_menu_destroy_path(id), as: :json
       response
     end
     let(:json) { JSON.parse(response.body) }


### PR DESCRIPTION
- Run: bin/rails g controller api/admin/appointments
- add admin api to fetch all appointment
- add api to delete an appointment
- naming route
- replace pending test
