### PR TITLE
WEB予約をとるsystem specを追加

### DIFF
--- a/app/javascript/shared/components/BirthdayInput.tsx
+++ b/app/javascript/shared/components/BirthdayInput.tsx
@@ -43,6 +43,7 @@ const BirthdayInput = (props: Props) => {
   return (
     <Box m={2}>
       <CustomTextField
+        id="birthday"
         value={value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           setValue(e.target.value);

--- a/app/javascript/shared/components/EmailInput.tsx
+++ b/app/javascript/shared/components/EmailInput.tsx
@@ -39,6 +39,7 @@ const EmailInput = (props: Props) => {
   return (
     <Box m={2}>
       <CustomTextField
+        id="email"
         value={value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           onChanged(e.target.value);

--- a/app/javascript/shared/components/FreeCommentInput.tsx
+++ b/app/javascript/shared/components/FreeCommentInput.tsx
@@ -11,6 +11,7 @@ const FreeCommentInput = (props: Props) => {
   return (
     <Box m={2}>
       <TextField
+        id="free-comment"
         value={value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           onChanged(e.target.value);

--- a/app/javascript/shared/components/KarteInformationInput.tsx
+++ b/app/javascript/shared/components/KarteInformationInput.tsx
@@ -52,18 +52,19 @@ const KarteInformationInput = (props: Props) => {
       >
         <FormControlLabel
           value="yes"
-          control={<Radio color="primary" />}
+          control={<Radio color="primary" data-testid="is-first-visit-true" />}
           label="はい"
         />
         <FormControlLabel
           value="no"
-          control={<Radio color="primary" />}
+          control={<Radio color="primary" data-testid="is-first-visit-false" />}
           label="いいえ"
         />
       </RadioGroup>
       {!value.isFirstVisit && (
         <>
           <CustomTextField
+            id="clinical-number"
             value={value.clinicalNumber}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               onChanged({ ...value, clinicalNumber: e.target.value });

--- a/app/javascript/shared/components/PhoneNumberInput.tsx
+++ b/app/javascript/shared/components/PhoneNumberInput.tsx
@@ -35,6 +35,7 @@ const PhoneNumberInput = (props: Props) => {
   return (
     <Box m={2}>
       <CustomTextField
+        id="phone-number"
         value={value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           onChanged(e.target.value);

--- a/app/javascript/shared/components/TimeTable.tsx
+++ b/app/javascript/shared/components/TimeTable.tsx
@@ -110,6 +110,7 @@ const TimeTable = (props: TimeTableProps) => {
                 >
                   {menu ? (
                     <IconButton
+                      data-testid="select-menu-button"
                       color={menu.isFilled ? "default" : "primary"}
                       onClick={() => {
                         onSelect(menu);

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,53 +47,54 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless　　
   end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless　　
+    driven_by :selenium_chrome_headless
   end
   #   # This allows you to limit a spec run to individual examples or groups
   #   # you care about by tagging them with `:focus` metadata. When nothing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium_chrome
   end
   #   # This allows you to limit a spec run to individual examples or groups
   #   # you care about by tagging them with `:focus` metadata. When nothing

--- a/spec/system/make_appointment_spec.rb
+++ b/spec/system/make_appointment_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Appointment, type: :system do
+  context 'when input parameters is valid' do
+    it 'makes an appointment for internal medicine' do
+      visit '/'
+      
+    end
+  end
+end

--- a/spec/system/make_appointment_spec.rb
+++ b/spec/system/make_appointment_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :system do
+  before { ActionController::Base.allow_forgery_protection = true }
+  after  { ActionController::Base.allow_forgery_protection = false }
+
   context 'when input parameters is valid' do
     it 'makes an appointment for internal medicine', js: true do
       visit '/'

--- a/spec/system/make_appointment_spec.rb
+++ b/spec/system/make_appointment_spec.rb
@@ -24,7 +24,15 @@ RSpec.describe Appointment, type: :system do
       fill_in 'birthday', with: '19910523'
       fill_in 'phone-number', with: '0000000000'
       fill_in 'email', with: 'appointment-spec@example.com'
-      
+      expect(page).to have_checked_field with: 'yes', visible: false
+      find('[value=no]', visible: false).choose
+      fill_in 'clinical-number', with: '00043'
+      find('[value=糖尿病]', visible: false).check
+      fill_in 'free-comment', with: "spec\n1型糖尿病\n2型糖尿病\nリブレ"
+      expect do
+        click_button '予約'
+        sleep 3
+      end.to change { Appointment.count }.by(1)
       sleep 5
     end
   end

--- a/spec/system/make_appointment_spec.rb
+++ b/spec/system/make_appointment_spec.rb
@@ -4,12 +4,27 @@ RSpec.describe Appointment, type: :system do
   before { ActionController::Base.allow_forgery_protection = true }
   after  { ActionController::Base.allow_forgery_protection = false }
 
+  before do
+    (1...7).each do |i|
+      CreateDailyAppointmentMenuService.new(Date.today + i.days).execute
+    end
+  end
+
   context 'when input parameters is valid' do
     it 'makes an appointment for internal medicine', js: true do
       visit '/'
       expect(page).to have_text('診療科を選択')
       click_button '内科'
       expect(page).to have_text('内科外来予約')
+      menu_buttons = all('[data-testid=select-menu-button]')
+      expect(menu_buttons.empty?).to be false
+      menu_buttons.sample.click
+      fill_in 'full_name', with: '架橋　太郎'
+      fill_in 'full_kana_name', with: 'カケハシ　タロウ'
+      fill_in 'birthday', with: '19910523'
+      fill_in 'phone-number', with: '0000000000'
+      fill_in 'email', with: 'appointment-spec@example.com'
+      
       sleep 5
     end
   end

--- a/spec/system/make_appointment_spec.rb
+++ b/spec/system/make_appointment_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Appointment, type: :system do
   context 'when input parameters is valid' do
-    it 'makes an appointment for internal medicine' do
+    it 'makes an appointment for internal medicine', js: true do
       visit '/'
-      
+      expect(page).to have_text('診療科を選択')
+      click_button '内科'
+      expect(page).to have_text('内科外来予約')
+      sleep 5
     end
   end
 end


### PR DESCRIPTION
- add capybara/spec to spec_helper.rb
- add config for driver
- add visit only spec
- visible browser
- click '内科'ボタン
- add data-testid to select menu buttons
- enable forgery protection in feature spec
- fill in some textfields
- system spec for making appointment for internal medicine
